### PR TITLE
Add Github CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,18 @@
+name: safe-modules
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+          cache-dependency-path: yarn.lock
+      - run: yarn
+      - run: yarn build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-modules-deployments",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Collection of Safe Modules singleton deployments",
   "homepage": "https://github.com/safe-global/safe-modules-deployments/",
   "license": "MIT",

--- a/src/safe-4337-module.ts
+++ b/src/safe-4337-module.ts
@@ -1,6 +1,6 @@
 import Safe4337Module030 from './assets/safe-4337-module/v0.3.0/safe-4337-module.json';
 import Safe4337Module020 from './assets/safe-4337-module/v0.2.0/safe-4337-module.json';
-import SafeModuleSetup030 from './assets/safe-4337-module/v0.3.0/safe-setup-module.json';
+import SafeModuleSetup030 from './assets/safe-4337-module/v0.3.0/safe-module-setup.json';
 import AddModulesLib020 from './assets/safe-4337-module/v0.2.0/add-modules-lib.json';
 import { DeploymentFilter, Deployment } from './types';
 import { applyFilterDefaults, findDeployment } from './utils';


### PR DESCRIPTION
This PR adds GitHub CI to the project that checks that the package builds. It turns out that there was a typo in the import statements that was causing build errors (which I dicovered when manually building locally). In order for CI to pass, the typo is fixed.

In addition, this PR also bumps the package version to v2.1.1 to make a new bugfix release including the import path update.
