### PR TITLE
Add Passkey Sepolia Deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "scripts": {
     "build": "yarn rimraf dist && tsc",
-    "lint": "eslint --max-warnings 0 .",
+    "lint": "eslint --max-warnings 0 src/",
     "prepack": "yarn build"
   },
   "repository": {

--- a/src/assets/safe-passkey-module/v0.2.0/daimo-p256-verifier.json
+++ b/src/assets/safe-passkey-module/v0.2.0/daimo-p256-verifier.json
@@ -1,0 +1,14 @@
+{
+  "released": true,
+  "contractName": "DaimoP256Verifier",
+  "version": "0.2.0",
+  "networkAddresses": {
+    "11155111": "0xc2b78104907F722DABAc4C69f826a522B2754De4"
+  },
+  "abi": [
+    {
+      "stateMutability": "nonpayable",
+      "type": "fallback"
+    }
+  ]
+}

--- a/src/assets/safe-passkey-module/v0.2.0/fcl-p256-verifier.json
+++ b/src/assets/safe-passkey-module/v0.2.0/fcl-p256-verifier.json
@@ -1,0 +1,14 @@
+{
+  "released": true,
+  "contractName": "FCLP256Verifier",
+  "version": "0.2.0",
+  "networkAddresses": {
+    "11155111": "0x445a0683e494ea0c5AF3E83c5159fBE47Cf9e765"
+  },
+  "abi": [
+    {
+      "stateMutability": "nonpayable",
+      "type": "fallback"
+    }
+  ]
+}

--- a/src/assets/safe-passkey-module/v0.2.0/safe-webauthn-signer-factory.json
+++ b/src/assets/safe-passkey-module/v0.2.0/safe-webauthn-signer-factory.json
@@ -1,0 +1,156 @@
+{
+  "released": true,
+  "contractName": "SafeWebAuthnSignerFactory",
+  "version": "0.2.0",
+  "networkAddresses": {
+    "11155111": "0xF7488fFbe67327ac9f37D5F722d83Fc900852Fbf"
+  },
+  "abi": [
+    {
+      "inputs": [],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "x",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "y",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "P256.Verifiers",
+          "name": "verifiers",
+          "type": "uint176"
+        }
+      ],
+      "name": "Created",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "SINGLETON",
+      "outputs": [
+        {
+          "internalType": "contract SafeWebAuthnSignerSingleton",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "x",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "y",
+          "type": "uint256"
+        },
+        {
+          "internalType": "P256.Verifiers",
+          "name": "verifiers",
+          "type": "uint176"
+        }
+      ],
+      "name": "createSigner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "x",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "y",
+          "type": "uint256"
+        },
+        {
+          "internalType": "P256.Verifiers",
+          "name": "verifiers",
+          "type": "uint176"
+        }
+      ],
+      "name": "getSigner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "message",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
+        },
+        {
+          "internalType": "uint256",
+          "name": "x",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "y",
+          "type": "uint256"
+        },
+        {
+          "internalType": "P256.Verifiers",
+          "name": "verifiers",
+          "type": "uint176"
+        }
+      ],
+      "name": "isValidSignatureForSigner",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "magicValue",
+          "type": "bytes4"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './allowance-module';
 export * from './safe-4337-module';
+export * from './safe-passkey-module';
 export * from './types';

--- a/src/safe-passkey-module.ts
+++ b/src/safe-passkey-module.ts
@@ -1,0 +1,22 @@
+import SafeWebAuthnSignerFactory020 from './assets/safe-passkey-module/v0.2.0/safe-webauthn-signer-factory.json';
+import DaimoP256Verifier020 from './assets/safe-passkey-module/v0.2.0/daimo-p256-verifier.json';
+import FCLP256Verifier020 from './assets/safe-passkey-module/v0.2.0/fcl-p256-verifier.json';
+import { DeploymentFilter, Deployment } from './types';
+import { applyFilterDefaults, findDeployment } from './utils';
+
+// The array should be sorted from the latest version to the oldest.
+const SAFE_WEBAUTHN_SIGNER_FACTORY_DEPLOYMENTS: Deployment[] = [SafeWebAuthnSignerFactory020];
+const DAIMO_P256_VERIFIER_DEPLOYMENTS: Deployment[] = [DaimoP256Verifier020];
+const FCL_P256_VERIFIER_DEPLOYMENTS: Deployment[] = [FCLP256Verifier020];
+
+export const getSafeWebAuthnSignerFactoryDeployment = (filter?: DeploymentFilter): Deployment | undefined => {
+  return findDeployment(applyFilterDefaults(filter), SAFE_WEBAUTHN_SIGNER_FACTORY_DEPLOYMENTS);
+};
+
+export const getDaimoP256VerifierDeployment = (filter?: DeploymentFilter): Deployment | undefined => {
+  return findDeployment(applyFilterDefaults(filter), DAIMO_P256_VERIFIER_DEPLOYMENTS);
+};
+
+export const getFCLP256VerifierDeployment = (filter?: DeploymentFilter): Deployment | undefined => {
+  return findDeployment(applyFilterDefaults(filter), FCL_P256_VERIFIER_DEPLOYMENTS);
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export interface Deployment {
   version: string;
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   abi: any[];
   networkAddresses: Record<string, string>;
   contractName: string;


### PR DESCRIPTION
This PR adds Sepolia deployments for the passkey contracts. Note that the `SafeWebAuthnSharedSigner` is omitted from the deployments as it has not yet been audited.