### PR TITLE
Add `defaultAddress` to Deployments

### DIFF
--- a/src/assets/allowance-module/v0.1.0/allowance-module.json
+++ b/src/assets/allowance-module/v0.1.0/allowance-module.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0xCFbFaC74C26F8647cBDb8c5caf80BB5b32E43134",
   "released": true,
   "contractName": "AllowanceModule",
   "version": "0.1.0",

--- a/src/assets/safe-4337-module/v0.2.0/add-modules-lib.json
+++ b/src/assets/safe-4337-module/v0.2.0/add-modules-lib.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0x8EcD4ec46D4D2a6B64fE960B3D64e8B94B2234eb",
   "released": true,
   "contractName": "AddModulesLib",
   "version": "0.2.0",

--- a/src/assets/safe-4337-module/v0.2.0/safe-4337-module.json
+++ b/src/assets/safe-4337-module/v0.2.0/safe-4337-module.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0xa581c4A4DB7175302464fF3C06380BC3270b4037",
   "released": true,
   "contractName": "Safe4337Module",
   "version": "0.2.0",

--- a/src/assets/safe-4337-module/v0.3.0/safe-4337-module.json
+++ b/src/assets/safe-4337-module/v0.3.0/safe-4337-module.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226",
   "released": true,
   "contractName": "Safe4337Module",
   "version": "0.3.0",

--- a/src/assets/safe-4337-module/v0.3.0/safe-module-setup.json
+++ b/src/assets/safe-4337-module/v0.3.0/safe-module-setup.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0x2dd68b007B46fBe91B9A7c3EDa5A7a1063cB5b47",
   "released": true,
   "contractName": "SafeModuleSetup",
   "version": "0.3.0",

--- a/src/assets/safe-passkey-module/v0.2.0/daimo-p256-verifier.json
+++ b/src/assets/safe-passkey-module/v0.2.0/daimo-p256-verifier.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0xc2b78104907F722DABAc4C69f826a522B2754De4",
   "released": true,
   "contractName": "DaimoP256Verifier",
   "version": "0.2.0",

--- a/src/assets/safe-passkey-module/v0.2.0/fcl-p256-verifier.json
+++ b/src/assets/safe-passkey-module/v0.2.0/fcl-p256-verifier.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0x445a0683e494ea0c5AF3E83c5159fBE47Cf9e765",
   "released": true,
   "contractName": "FCLP256Verifier",
   "version": "0.2.0",

--- a/src/assets/safe-passkey-module/v0.2.0/safe-webauthn-signer-factory.json
+++ b/src/assets/safe-passkey-module/v0.2.0/safe-webauthn-signer-factory.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0xF7488fFbe67327ac9f37D5F722d83Fc900852Fbf",
   "released": true,
   "contractName": "SafeWebAuthnSignerFactory",
   "version": "0.2.0",

--- a/src/assets/safe-recovery-module/v0.1.0/social-recovery-module.json
+++ b/src/assets/safe-recovery-module/v0.1.0/social-recovery-module.json
@@ -1,4 +1,5 @@
 {
+  "defaultAddress": "0x4Aa5Bf7D840aC607cb5BD3249e6Af6FC86C04897",
   "released": true,
   "contractName": "SocialRecoveryModule",
   "version": "0.1.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,11 @@
 export interface Deployment {
+  defaultAddress: string;
+  released: boolean;
+  contractName: string;
   version: string;
+  networkAddresses: Record<string, string>;
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   abi: any[];
-  networkAddresses: Record<string, string>;
-  contractName: string;
-  released: boolean;
 }
 
 export interface DeploymentFilter {


### PR DESCRIPTION
I noticed when building with the `safe-module-deployments` package, that the `defaultAddress` field was missing from the deployment files. This PR adds these to all deployments as well as adjusts the typings to reflect this new field.