### PR TITLE
Bump v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-modules-deployments",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Collection of Safe modules contract deployments",
   "homepage": "https://github.com/safe-global/safe-modules-deployments/",
   "license": "MIT",


### PR DESCRIPTION
This PR bumps that package.json version in preparation for a release containing the Passkey v0.2.1 contract deployments.