### PR TITLE
chore: bump version v3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-modules-deployments",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Collection of Safe modules contract deployments",
   "homepage": "https://github.com/safe-global/safe-modules-deployments/",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bumps package version from `3.0.1` to `3.0.2` to publish recent deployment additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)