### PR TITLE
feat: add bytecode consistency review for module deployment PRs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,34 @@
+name: Review
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'src/assets/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull Request number to review'
+        required: true
+        type: number
+
+permissions: {}
+
+jobs:
+  review:
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Review PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash bin/github-review.sh ${{ inputs.pr_number || github.event.number }}

--- a/bin/github-review.sh
+++ b/bin/github-review.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# For each module deployment JSON file changed in a PR, diffs it against the PR's base
+# commit to find which chain ID(s) were added/changed, then verifies each one's bytecode
+# against an already-registered (unchanged) reference chain in the same file.
+#
+# USAGE
+#     bash ./bin/github-review.sh <PR>
+
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+This script verifies deployment bytecode consistency for the asset files changed in a PR.
+
+USAGE
+    bash ./bin/github-review.sh <PR>
+
+ARGUMENTS
+    PR          The GitHub PR number
+
+EXAMPLES
+    bash ./bin/github-review.sh 123
+EOF
+}
+
+if ! command -v gh &> /dev/null; then
+    echo "ERROR: Please install the 'gh' GitHub CLI" 1>&2
+    exit 1
+fi
+
+if [[ "$#" -ne 1 ]]; then
+    echo "ERROR: Invalid number of arguments" 1>&2
+    usage
+    exit 1
+fi
+if ! [[ $1 =~ ^[0-9]+$ ]]; then
+    echo "ERROR: $1 is not a valid GitHub PR number" 1>&2
+    exit 1
+fi
+pr=$1
+
+if ! pr_state="$(gh pr view "$pr" --json state --jq '.state' 2>/dev/null)"; then
+    echo "ERROR: PR #$pr does not exist in this repository" 1>&2
+    exit 1
+fi
+if [[ "$pr_state" != "OPEN" ]]; then
+    echo "ERROR: PR #$pr is not open (current state: $pr_state)" 1>&2
+    exit 1
+fi
+
+base_sha="$(gh pr view "$pr" --json baseRefOid --jq '.baseRefOid')"
+if [[ -z "$base_sha" ]]; then
+    echo "ERROR: Could not determine base commit for PR #$pr" 1>&2
+    exit 1
+fi
+git fetch origin "$base_sha" --depth=1 2>/dev/null || true
+
+files="$(gh pr diff "$pr" --name-only | grep -E '^src/assets/.*\.json$' || true)"
+if [[ -z "$files" ]]; then
+    echo "No src/assets/*.json files changed in PR #$pr, nothing to review."
+    exit 0
+fi
+
+# Assume that if `GITHUB_HEAD_REF` is set, we're running in CI and the PR's files are
+# already checked out; otherwise apply the patch locally on top of the current branch.
+applied_patch=0
+if [[ -z "${GITHUB_HEAD_REF:-}" ]]; then
+    gh pr diff "$pr" --patch | git apply --include 'src/assets/**' --verbose
+    applied_patch=1
+fi
+
+status=0
+while IFS= read -r file; do
+    echo "Reviewing $file"
+    pnpm run --silent review:verify-deployment "$file" --base "$base_sha" || status=1
+done <<< "$files"
+
+if [[ "$applied_patch" -eq 1 ]]; then
+    git restore --ignore-unmerged -- src/assets
+fi
+
+exit $status

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "lint:ts": "eslint --max-warnings 0 src/",
     "prepare": "pnpm run build",
     "test": "jest",
-    "update-registry": "tsx scripts/update-registry.ts"
+    "update-registry": "tsx scripts/update-registry.ts",
+    "review:verify-deployment": "tsx scripts/review/verifyDeployment.ts"
   },
   "jest": {
     "preset": "ts-jest",

--- a/scripts/review/verifyDeployment.ts
+++ b/scripts/review/verifyDeployment.ts
@@ -1,0 +1,150 @@
+#!/usr/bin/env tsx
+/**
+ * Diffs an asset JSON file against its content at a base commit to find which chain
+ * ID(s) were added or changed, then verifies each one's bytecode against an
+ * already-registered (unchanged) reference chain in the same file.
+ *
+ * These are deterministic CREATE2 deployments, so the runtime bytecode for a given
+ * module+version must be byte-identical on every chain it's deployed on. There is no
+ * stored "expected" codeHash in this schema (unlike safe-deployments), so this checks
+ * cross-chain consistency instead of comparing against a stored hash.
+ *
+ * Only chains that actually changed in the diff are checked — not every chain in the
+ * file — so unrelated, already-verified chains can't fail an unrelated PR.
+ *
+ * Usage:
+ *   tsx scripts/review/verifyDeployment.ts <path-to-asset.json> --base <git-ref-or-sha>
+ */
+import { execFileSync } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import { createPublicClient, http, keccak256 } from 'viem';
+
+function parseArgs(): { assetPath: string; base: string } {
+  const args = process.argv.slice(2);
+  const assetPath = args[0];
+  const baseIndex = args.indexOf('--base');
+  const base = baseIndex !== -1 ? args[baseIndex + 1] : undefined;
+
+  if (!assetPath || !base) {
+    throw new Error('Usage: tsx scripts/review/verifyDeployment.ts <path-to-asset.json> --base <git-ref-or-sha>');
+  }
+  return { assetPath, base };
+}
+
+function readNetworkAddressesAt(ref: string, assetPath: string): Record<string, string> {
+  try {
+    const content = execFileSync('git', ['show', `${ref}:${assetPath}`], { encoding: 'utf-8' });
+    return JSON.parse(content).networkAddresses ?? {};
+  } catch {
+    // File didn't exist at the base commit (e.g. brand new version/module in this PR)
+    return {};
+  }
+}
+
+async function fetchPublicRpcs(chainId: string): Promise<string[]> {
+  const response = await fetch('https://chainlist.org/rpcs.json');
+  if (!response.ok) {
+    throw new Error(`Failed to fetch chainlist from DefiLlama (HTTP ${response.status})`);
+  }
+  const chainlist = (await response.json()) as Array<{
+    chainId: number;
+    rpc: Array<{ url: string; tracking?: string }>;
+  }>;
+  const chain = chainlist.find((entry) => `${entry.chainId}` === chainId);
+  const urls = (chain?.rpc ?? [])
+    .filter(({ url }) => url.startsWith('http'))
+    .sort((a, b) => (a.tracking === 'none' ? -1 : 1) - (b.tracking === 'none' ? -1 : 1))
+    .map(({ url }) => url);
+  if (urls.length === 0) {
+    throw new Error(`No public RPC found for chain ID ${chainId} on DefiLlama's ChainList`);
+  }
+  return urls;
+}
+
+async function getBytecodeHash(chainId: string, address: string): Promise<`0x${string}`> {
+  const rpcUrls = await fetchPublicRpcs(chainId);
+
+  let lastError: unknown;
+  for (const rpcUrl of rpcUrls.slice(0, 3)) {
+    try {
+      const client = createPublicClient({ transport: http(rpcUrl) });
+      const code = await client.getCode({ address: address as `0x${string}` });
+      if (!code || code === '0x') {
+        throw new Error(`No bytecode deployed at ${address} on chain ${chainId}`);
+      }
+      return keccak256(code);
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw new Error(
+    `Failed to fetch bytecode for chain ${chainId} after trying ${Math.min(rpcUrls.length, 3)} RPC(s): ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  );
+}
+
+async function main() {
+  const { assetPath, base } = parseArgs();
+
+  const oldNetworkAddresses = readNetworkAddressesAt(base, assetPath);
+  const newContent = JSON.parse(await fs.readFile(assetPath, 'utf-8'));
+  const newNetworkAddresses = newContent.networkAddresses as Record<string, string>;
+  const contractName = newContent.contractName;
+
+  const changedChainIds = Object.keys(newNetworkAddresses).filter(
+    (chainId) => oldNetworkAddresses[chainId] !== newNetworkAddresses[chainId],
+  );
+
+  if (changedChainIds.length === 0) {
+    console.log(`${contractName}: no networkAddresses changes in ${assetPath}, nothing to verify.`);
+    return;
+  }
+
+  const referenceChainId = Object.keys(oldNetworkAddresses).find(
+    (chainId) => !changedChainIds.includes(chainId) && oldNetworkAddresses[chainId] === newNetworkAddresses[chainId],
+  );
+
+  if (!referenceChainId) {
+    console.warn(
+      `⚠️  ${contractName}: no unchanged reference chain available in ${assetPath} — cannot cross-check ` +
+        `bytecode for chain(s) ${changedChainIds.join(', ')}.`,
+    );
+    return;
+  }
+
+  console.log(`Reference chain: ${referenceChainId} (${oldNetworkAddresses[referenceChainId]})`);
+  const referenceHash = await getBytecodeHash(referenceChainId, oldNetworkAddresses[referenceChainId]);
+  console.log(`  hash: ${referenceHash}`);
+
+  const problems: string[] = [];
+  const okChainIds: string[] = [];
+  for (const chainId of changedChainIds) {
+    const address = newNetworkAddresses[chainId];
+    try {
+      const hash = await getBytecodeHash(chainId, address);
+      console.log(`  chain ${chainId} (${address}): ${hash}`);
+      if (hash !== referenceHash) {
+        problems.push(`chain ${chainId} (${address}) has hash ${hash}, expected ${referenceHash}`);
+      } else {
+        okChainIds.push(chainId);
+      }
+    } catch (err) {
+      problems.push(`chain ${chainId} (${address}): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `${contractName}: ${problems.length} of ${changedChainIds.length} changed chain(s) failed verification ` +
+        `against reference chain ${referenceChainId}:\n${problems.join('\n')}`,
+    );
+  }
+
+  console.log(`✓ ${contractName}: chain(s) ${okChainIds.join(', ')} match reference chain ${referenceChainId}`);
+}
+
+main().catch((err) => {
+  console.error(`ERROR: ${err.message}`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
- Related with [PLA-860](https://linear.app/safe-global/issue/PLA-860/deployment-scripts-check-deployed-bytecode-match)

Summary

- update-registry.yml writes new addresses with zero on-chain verification, only format checks. Nothing confirms the bytecode is actually correct.
- Unlike safe-deployments, this schema has no stored codeHash per chain, so adds a Review workflow (mirrors safe-deployments' review.yml) that instead cross-checks: on PRs touching src/assets/**, diffs each changed file against the base commit to find which chain(s) changed, then verifies each one's bytecode hash against an already-registered reference chain (deterministic CREATE2 deploys must be byte-identical everywhere).
- Only changed chains are checked, and all of them are checked before failing (not just the first broken one).