### PR TITLE
chore: bump version v3.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-modules-deployments",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "description": "Collection of Safe modules contract deployments",
   "homepage": "https://github.com/safe-global/safe-modules-deployments/",
   "license": "MIT",


### PR DESCRIPTION
Bumps the package version to v3.0.9 so the recently merged deployment additions can be released to npm:

- #209 — allowance-module v0.1.1 for chains 10 (Optimism) and 42161 (Arbitrum)
- #211 — allowance-module v0.1.1 for chain 36900

Note: the automated `Bump Version` workflow has been failing on every push to main because the repository now requires verified commit signatures, and the bot commit it pushes is unsigned (see e.g. run 30630633819). Hence the manual bump PR, matching the convention of #196. The workflow could be fixed by creating the bump commit via the GraphQL `createCommitOnBranch` mutation, which GitHub signs automatically.

After merge, this needs an npm publish of 3.0.9 so `safe-wallet-monorepo` can pick it up and spending limits become available on Optimism/Arbitrum in the web app.